### PR TITLE
ci: build before publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           python-version: 3.10
 
+      - name: Build
+        run: uv build
+
       - name: Publish to PyPI
         run: uv publish
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Build
         run: uv build


### PR DESCRIPTION
[successfully published](https://github.com/mcp-auth/python/actions/runs/14870431469)