### PR TITLE
fix: set correct dist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,5 +42,6 @@ dev = [
 branch = true
 source = ["mcpauth"]
 
-[tool.setuptools]
-packages = ["mcpauth"]
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["mcpauth*"]


### PR DESCRIPTION
use find technique to include all source files

### Testing

`uv build` now shows

```bash
adding 'mcpauth/__init__.py'
adding 'mcpauth/config.py'
adding 'mcpauth/exceptions.py'
adding 'mcpauth/types.py'
adding 'mcpauth/middleware/create_bearer_auth.py'
adding 'mcpauth/utils/__init__.py'
adding 'mcpauth/utils/_create_verify_jwt.py'
adding 'mcpauth/utils/_fetch_server_config.py'
adding 'mcpauth/utils/_validate_server_config.py'
```