### PR TITLE
refactor: loose client id requirement and accept azp

### DIFF
--- a/mcpauth/types.py
+++ b/mcpauth/types.py
@@ -139,12 +139,19 @@ class JwtPayload(BaseModel):
     - https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier
     """
 
-    client_id: NonEmptyString
+    client_id: Optional[str] = None
     """
     The client ID of the OAuth client that the token was issued to. This is typically the client ID
     registered with the OAuth / OIDC provider.
 
     Some providers may use 'application ID' or similar terms instead of 'client ID'.
+    """
+
+    azp: Optional[str] = None
+    """
+    The `azp` (authorized party) claim of the token, which indicates the client ID of the party
+    that authorized the request. Many providers use this claim to indicate the client ID of the
+    application instead of `client_id`.
     """
 
     sub: NonEmptyString

--- a/mcpauth/types.py
+++ b/mcpauth/types.py
@@ -35,6 +35,14 @@ class AuthInfo(BaseModel):
     registered with the OAuth / OIDC provider.
 
     Some providers may use 'application ID' or similar terms instead of 'client ID'.
+
+    Note:
+    This value accept either `client_id` (RFC 9068) or `azp` claim for better compatibility.
+    While `client_id` is required by RFC 9068 for JWT access tokens, many providers (Auth0,
+    Microsoft, Google) may use or support `azp` claim.
+    
+    See Also:
+    https://github.com/mcp-auth/js/issues/28 for detailed discussion
     """
 
     scopes: List[str] = []

--- a/mcpauth/utils/_create_verify_jwt.py
+++ b/mcpauth/utils/_create_verify_jwt.py
@@ -60,7 +60,11 @@ def create_verify_jwt(
             return AuthInfo(
                 token=token,
                 issuer=base_model.iss,
-                client_id=base_model.client_id,
+                client_id=(
+                    base_model.client_id
+                    if base_model.client_id is not None
+                    else base_model.azp
+                ),
                 subject=base_model.sub,
                 audience=base_model.aud,
                 scopes=(scopes.split(" ") if isinstance(scopes, str) else scopes) or [],

--- a/tests/utils/create_verify_jwt_test.py
+++ b/tests/utils/create_verify_jwt_test.py
@@ -239,7 +239,7 @@ class TestCreateVerifyJwtNormalBehavior:
         jwt_token = create_jwt(claims)
         result = verify_jwt(jwt_token)
         assert result.issuer == claims["iss"]
-        assert result.client_id is ""
+        assert result.client_id == ""
         assert result.subject == claims["sub"]
         assert result.audience == claims["aud"]
         assert result.scopes == []


### PR DESCRIPTION
## Summary

An update originated from https://github.com/mcp-auth/js/issues/28.

Improved handling of the `client_id` field in the built-in JWT verifier and added support for the `azp` (authorized party) field. The logic now falls back to the `azp` field if `client_id` is missing or malformed. If neither field is valid, it defaults to an empty string.