### PR TITLE
fix: use `scopes_supported` in OAuth server metadata

### DIFF
--- a/mcpauth/config.py
+++ b/mcpauth/config.py
@@ -138,7 +138,12 @@ class AuthorizationServerMetadata(BaseModel):
     [[RFC7591](https://www.rfc-editor.org/rfc/rfc7591)].
     """
 
-    scope_supported: Optional[List[str]] = None
+    scopes_supported: Optional[List[str]] = None
+    """
+    JSON array containing a list of the OAuth 2.0 `scope` values that this authorization
+    server supports.
+    [[RFC8414](https://datatracker.ietf.org/doc/html/rfc8414#section-2)]
+    """
 
     response_types_supported: List[str]
     """

--- a/tests/utils/fetch_server_config_test.py
+++ b/tests/utils/fetch_server_config_test.py
@@ -65,6 +65,7 @@ class TestFetchServerConfigByWellKnownUrl:
             "issuer": sample_issuer,
             "authorization_endpoint": "https://example.com/oauth/authorize",
             "token_endpoint": "https://example.com/oauth/token",
+            "scopes_supported": ["scope1", "scope2", "scope3"],
         }
 
         responses.add(responses.GET, url=sample_well_known_url, json=sample_response)
@@ -83,6 +84,7 @@ class TestFetchServerConfigByWellKnownUrl:
         )
         assert config.metadata.token_endpoint == "https://example.com/oauth/token"
         assert config.metadata.response_types_supported == ["code"]
+        assert config.metadata.scopes_supported == ["scope1", "scope2", "scope3"]
 
     @responses.activate
     def test_fetch_server_config_oauth_success(self):
@@ -144,6 +146,7 @@ class TestFetchServerConfigByWellKnownUrl:
             "authorization_endpoint": "https://example.com/authorize",
             "token_endpoint": "https://example.com/token",
             "response_types_supported": ["code"],
+            "scopes_supported": ["openid", "profile", "email"],
         }
 
         responses.add(
@@ -159,6 +162,7 @@ class TestFetchServerConfigByWellKnownUrl:
         assert config.metadata.authorization_endpoint == "https://example.com/authorize"
         assert config.metadata.token_endpoint == "https://example.com/token"
         assert config.metadata.response_types_supported == ["code"]
+        assert config.metadata.scopes_supported == ["openid", "profile", "email"]
 
     @responses.activate
     def test_fetch_server_config_oidc_with_path_success(self):


### PR DESCRIPTION
According to the [RFC](https://datatracker.ietf.org/doc/html/rfc8414#section-2), the supported scopes filed name should be scopes_supported rather than scope_supported.